### PR TITLE
Add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,55 @@
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '27 4 * * 2'
+  push:
+    branches: [ "cggmp24/m" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to OpenSSF REST API for easy access by consumers.
+          # Allows the repository to be included in the Scorecard monitoring list.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@4e94bd11f71e507f7f87df81788dff88d1dacbfb # v3.30.7
+        with:
+          sarif_file: results.sarif

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,4 +69,4 @@ it following the procedure described in [SECURITY.md](./SECURITY.md).
 
 Feel free to reach out to us [in Discord] as well.
 
-[in Discord]: https://discordapp.com/channels/905194001349627914/1285268686147424388
+[in Discord]: https://discord.com/invite/hyperledger

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/LFDT-Lockness/generic-ecies/badge)](https://scorecard.dev/viewer/?uri=github.com/LFDT-Lockness/generic-ecies)
+
 # generic-ecies
 
 ECIES is a scheme for efficient ciphers with asymmetric key using elliptic


### PR DESCRIPTION
Adds the OpenSSF Scorecard GitHub Action and a Scorecard badge to the README.

The workflow runs weekly (and on `branch_protection_rule` / pushes to the default branch) and uploads results to:
- the repository's Code Scanning dashboard (SARIF), and
- the public OpenSSF results API (so the repo gets a Scorecard badge at https://scorecard.dev/).

Refs:
- https://openssf.org/projects/scorecard/
- https://github.com/marketplace/actions/ossf-scorecard-action

All third-party actions are pinned by commit SHA.